### PR TITLE
Configurable Outline Thickness for Hearing and Tremorsense

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -13,5 +13,7 @@
     "VISION5E.LightPerception": "Light Perception",
     "VISION5E.UmbralSight": "Umbral Sight",
     "VISION5E.Settings.DefaultHearingRangeN": "Default Hearing Range",
-    "VISION5E.Settings.DefaultHearingRangeL": "Configure how far tokens can hear by default. Requires the world to be reloaded."
+    "VISION5E.Settings.DefaultHearingRangeL": "Configure how far tokens can hear by default. Requires the world to be reloaded.",
+    "VISION5E.Settings.DefaultOutlineThicknessN": "Thickness of Imprecise Sense Outline",
+    "VISION5E.Settings.DefaultOutlineThicknessL": "Configure the outline thickness of Tokens seen by Imprecise Senses. Requires the world to be reloaded."
 }

--- a/scripts/detection-modes/hearing.mjs
+++ b/scripts/detection-modes/hearing.mjs
@@ -20,11 +20,13 @@ export class DetectionModeHearing extends DetectionMode {
 
     /** @override */
     static getDetectionFilter() {
-        return this._detectionFilter ??= OutlineOverlayFilter.create({
+        let filter = this._detectionFilter ??= OutlineOverlayFilter.create({
             outlineColor: [1, 1, 1, 1],
             knockout: true,
             wave: true
         });
+        filter.thickness = game.settings.get("vision-5e", "defaultOutlineThickness");
+        return filter;
     }
 
     /** @override */

--- a/scripts/detection-modes/tremorsense.mjs
+++ b/scripts/detection-modes/tremorsense.mjs
@@ -20,11 +20,13 @@ export class DetectionModeTremorsense extends DetectionMode {
 
     /** @override */
     static getDetectionFilter() {
-        return this._detectionFilter ??= OutlineOverlayFilter.create({
+        let filter = this._detectionFilter ??= OutlineOverlayFilter.create({
             outlineColor: [1, 0, 1, 1],
             knockout: true,
             wave: true
         });
+        filter.thickness = game.settings.get("vision-5e", "defaultOutlineThickness");
+        return filter;
     }
 
     /** @override */

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -42,9 +42,9 @@ Hooks.once("init", () => {
     const defaultOutlineThickness = game.settings.get("vision-5e", "defaultOutlineThickness") || 3;
 
     if (!Number.isNaN(defaultOutlineThickness)) {
-        settings.defaultHearingRange = defaultOutlineThickness
+        settings.defaultOutlineThickness = defaultOutlineThickness
     } else {
-        settings.defaultHearingRange = 3;
+        settings.defaultOutlineThickness = 3;
     }
 });
 
@@ -66,4 +66,6 @@ Hooks.on("renderSettingsConfig", (app, html) => {
     defaultOutlineThickness.min = 0;
     defaultOutlineThickness.step = 1;
     defaultOutlineThickness.required = true;
+
+    html[0].querySelector(`[data-setting-id="vision-5e.defaultOutlineThickness"]`).classList.add("slim");
 });

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -24,6 +24,28 @@ Hooks.once("init", () => {
     } else {
         settings.defaultHearingRange = 0;
     }
+
+    game.settings.register(
+        "vision-5e",
+        "defaultOutlineThickness",
+        {
+            name: "VISION5E.Settings.DefaultOutlineThicknessN",
+            hint: "VISION5E.Settings.DefaultOutlineThicknessL",
+            scope: "world",
+            config: true,
+            requiresReload: true,
+            type: Number,
+            default: 3
+        }
+    );
+
+    const defaultOutlineThickness = game.settings.get("vision-5e", "defaultOutlineThickness") || 3;
+
+    if (!Number.isNaN(defaultOutlineThickness)) {
+        settings.defaultHearingRange = defaultOutlineThickness
+    } else {
+        settings.defaultHearingRange = 3;
+    }
 });
 
 Hooks.on("renderSettingsConfig", (app, html) => {
@@ -37,4 +59,11 @@ Hooks.on("renderSettingsConfig", (app, html) => {
     html[0].querySelector(`[data-setting-id="vision-5e.defaultHearingRange"]`).classList.add("slim");
     html[0].querySelector(`[data-setting-id="vision-5e.defaultHearingRange"] label`)
         .insertAdjacentHTML("beforeend", ` <span class="units">(ft)</span>`);
+
+    const defaultOutlineThickness = html[0].querySelector(`input[name="vision-5e.defaultOutlineThickness"]`);
+
+    defaultOutlineThickness.value ||= 3;
+    defaultOutlineThickness.min = 0;
+    defaultOutlineThickness.step = 1;
+    defaultOutlineThickness.required = true;
 });


### PR DESCRIPTION
Adds configurable outline thickness for Hearing and Tremorsense for #23 
![image](https://github.com/dev7355608/vision-5e/assets/25332081/d8190b33-743e-441a-a6c5-f3a7631dbb02)

It only applies to these two senses since they are the only imprecise senses that use OutlineOverlayFilter

The setting defaults to 3 which is the default without the setting

![image](https://github.com/dev7355608/vision-5e/assets/25332081/c68055e0-fc37-46b3-83c3-ceda5f775f38)

