### PR TITLE
[#64] Remove filter from isMagical to ignore common rarity

### DIFF
--- a/scripts/detection-modes/detect-magic.mjs
+++ b/scripts/detection-modes/detect-magic.mjs
@@ -81,7 +81,7 @@ export class DetectionModeDetectMagic extends DetectionModeDetect {
                 || type === "loot"
                 || type === "tool"
                 || type === "weapon")
-                && !!item.system.rarity && item.system.rarity !== "common"
+                && !!item.system.rarity
                 || type === "weapon" && item.system.properties.mgc;
         };
 


### PR DESCRIPTION
[#64] Remove filter from isMagical to ignore common rarity, so common rarity is detected.

The issue described in the readme about mundane items erroneously being labeled as common in the dnd5e srd seems fixed in the present version (2.4.1).