### PR TITLE
Use formula for hearing range

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A token gains ...
 - _See Invisibility_ if the actor has an active effect with the name `See Invisibility`[\*](#translations).
 - _Witch Sight_ if the actor has a feat with the name `Witch Sight`[\*](#translations), `Invocation: Witch Sight`, `Invocations: Witch Sight`, `Eldritch Invocation: Witch Sight`, `Eldritch Invocations: Witch Sight`, or `Eldritch Adept: Witch Sight`.
 
-By default all tokens have hearing range of 30 feet. The default hearing range can be configured in the module settings.
+By default all tokens have hearing range of 15 + 2.5 * (*Passive Perception* - 10) feet (`15 + 2.5 * (@skills.prc.passive - 10)`). The default hearing range can be configured in the module settings.
 
 If you use metric units, you need to change the units in the module settings.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,5 +18,7 @@
     "VISION5E.WitchSight": "Witch Sight",
     "VISION5E.Settings.DefaultHearingRangeN": "Default Hearing Range",
     "VISION5E.Settings.DefaultHearingRangeL": "Configure how far tokens can hear by default. Requires the world to be reloaded.",
+    "VISION5E.Settings.DefaultHearingRangeFormulaN": "Use Hearing Range Formula",
+    "VISION5E.Settings.DefaultHearingRangeFormulaL": "Use a formula for hearing range. Overrides default hearing range. Requires the world to be reloaded.",
     "VISION5E.Settings.UnitsL": "Configure which unit of length is used. Requires the world to be reloaded."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,7 +18,5 @@
     "VISION5E.WitchSight": "Witch Sight",
     "VISION5E.Settings.DefaultHearingRangeN": "Default Hearing Range",
     "VISION5E.Settings.DefaultHearingRangeL": "Configure how far tokens can hear by default. Requires the world to be reloaded.",
-    "VISION5E.Settings.DefaultHearingRangeFormulaN": "Use Hearing Range Formula",
-    "VISION5E.Settings.DefaultHearingRangeFormulaL": "Use a formula for hearing range. Overrides default hearing range. Requires the world to be reloaded.",
     "VISION5E.Settings.UnitsL": "Configure which unit of length is used. Requires the world to be reloaded."
 }

--- a/scripts/automation.mjs
+++ b/scripts/automation.mjs
@@ -59,7 +59,13 @@ function getInheritedDetectionModes(actor) {
     modes.seeAll = senses.truesight;
     modes.blindsight = senses.blindsight;
     modes.feelTremor = senses.tremorsense;
-    modes.hearing = settings.defaultHearingRange;
+    if (settings.defaultHearingRangeFormula) {
+        let vRoll = new Roll(settings.defaultHearingRangeFormula, {actor});
+		vRoll.evaluate({async: false});
+		modes.hearing = vRoll.total;
+    } else {
+        modes.hearing = settings.defaultHearingRange;
+    }
 
     for (const effect of actor.appliedEffects) {
         const mode = getEffect(effect.name);

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -30,33 +30,21 @@ Hooks.once("init", () => {
             scope: "world",
             config: true,
             requiresReload: true,
-            type: Number,
-            default: 30
-        }
-    );
-
-    game.settings.register(
-        "vision-5e",
-        "defaultHearingRangeFormula",
-        {
-            name: "VISION5E.Settings.DefaultHearingRangeFormulaN",
-            hint: "VISION5E.Settings.DefaultHearingRangeFormulaL",
-            scope: "world",
-            config: true,
-            requiresReload: true,
             type: String,
-            default: ''
+            default: "15 + 2.5 * (@skills.prc.passive - 10)"
         }
     );
 
-    const defaultHearingRange = game.settings.get("vision-5e", "defaultHearingRange") || 0;
+    const defaultHearingRange = game.settings.get("vision-5e", "defaultHearingRange");
 
-    if (!Number.isNaN(defaultHearingRange)) {
-        settings.defaultHearingRange = defaultHearingRange
+    if (!Number.isNaN(Number(defaultHearingRange))) {
+        settings.defaultHearingRange = Number(defaultHearingRange);
+    } else if (typeof defaultHearingRange === "string" && defaultHearingRange.trim() !== "") {
+        settings.defaultHearingRange = defaultHearingRange.trim();
     } else {
         settings.defaultHearingRange = 0;
     }
-    settings.defaultHearingRangeFormula = game.settings.get("vision-5e", "defaultHearingRangeFormula") || '';
+
     settings.metric = game.settings.get("vision-5e", "units") === "m";
 });
 
@@ -75,7 +63,6 @@ Hooks.on("renderSettingsConfig", (app, html) => {
     defaultHearingRange.placeholder = "0";
     defaultHearingRange.dataset.units = units;
 
-    html[0].querySelector(`[data-setting-id="vision-5e.defaultHearingRange"]`).classList.add("slim");
     html[0].querySelector(`[data-setting-id="vision-5e.defaultHearingRange"] label`)
         .insertAdjacentHTML("beforeend", ` <span class="units">(${units})</span>`);
     html[0].querySelector(`select[name="vision-5e.units"]`).addEventListener("change", (event) => {

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -35,6 +35,20 @@ Hooks.once("init", () => {
         }
     );
 
+    game.settings.register(
+        "vision-5e",
+        "defaultHearingRangeFormula",
+        {
+            name: "VISION5E.Settings.DefaultHearingRangeFormulaN",
+            hint: "VISION5E.Settings.DefaultHearingRangeFormulaL",
+            scope: "world",
+            config: true,
+            requiresReload: true,
+            type: String,
+            default: ''
+        }
+    );
+
     const defaultHearingRange = game.settings.get("vision-5e", "defaultHearingRange") || 0;
 
     if (!Number.isNaN(defaultHearingRange)) {
@@ -42,7 +56,7 @@ Hooks.once("init", () => {
     } else {
         settings.defaultHearingRange = 0;
     }
-
+    settings.defaultHearingRangeFormula = game.settings.get("vision-5e", "defaultHearingRangeFormula") || '';
     settings.metric = game.settings.get("vision-5e", "units") === "m";
 });
 


### PR DESCRIPTION
Based on discussion here: [https://ptb.discord.com/channels/915186263609454632/1187628233181642843](https://ptb.discord.com/channels/915186263609454632/1187628233181642843) (Midi Discord).

People want a way to adjust hearing based on actor attributes, like passive perception. This PR adds a new setting to set the default hearing range to a formula instead of a number.


Value as an example, defaults to blank. When blank defaults back to number setting.

![image](https://github.com/dev7355608/vision-5e/assets/25332081/27cfa2e0-1a66-41b1-8304-f98b729adb30)
