### PR TITLE
ability to set unconscious actors to retain vision

### DIFF
--- a/scripts/detection-modes/blindsense.mjs
+++ b/scripts/detection-modes/blindsense.mjs
@@ -42,7 +42,7 @@ export default class DetectionModeBlindsense extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/blindsight.mjs
+++ b/scripts/detection-modes/blindsight.mjs
@@ -41,7 +41,7 @@ export default class DetectionModeBlindsight extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/darkvision.mjs
+++ b/scripts/detection-modes/darkvision.mjs
@@ -46,7 +46,7 @@ export default class DetectionModeDarkvision extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/detect.mjs
+++ b/scripts/detection-modes/detect.mjs
@@ -34,7 +34,7 @@ export default class DetectionModeDetect extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/devils-sight.mjs
+++ b/scripts/detection-modes/devils-sight.mjs
@@ -42,7 +42,7 @@ export default class DetectionModeDevilsSight extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/divine-sense.mjs
+++ b/scripts/detection-modes/divine-sense.mjs
@@ -43,7 +43,7 @@ export default class DetectionModeDivineSense extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/hearing.mjs
+++ b/scripts/detection-modes/hearing.mjs
@@ -41,7 +41,7 @@ export default class DetectionModeHearing extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEAFENED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/light-perception.mjs
+++ b/scripts/detection-modes/light-perception.mjs
@@ -42,7 +42,7 @@ export default class DetectionModeLightPerception extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/tremorsense.mjs
+++ b/scripts/detection-modes/tremorsense.mjs
@@ -46,7 +46,7 @@ export default class DetectionModeTremorsense extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.HOVERING)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/detection-modes/truesight.mjs
+++ b/scripts/detection-modes/truesight.mjs
@@ -37,7 +37,7 @@ export default class DetectionModeTruesight extends DetectionMode {
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || source.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || source.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (source.document.hasStatusEffect(CONFIG.specialStatusEffects.Unconscious) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             return false;
         }
 

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -18,6 +18,20 @@ Hooks.once("init", () => {
         }
     );
 
+    game.settings.register(
+        "vision-5e",
+        "unconsciousRetainsVision",
+        {
+            name: "Unconscious Retains Vision",
+            hint: "Unconscious creatures retain their vision",
+            scope: "world",
+            config: true,
+            requiresReload: false,
+            type: Boolean,
+            default: false
+        }
+    );
+
     Hooks.on("renderSettingsConfig", (app, html) => {
         if (!game.user.isGM) {
             return;

--- a/scripts/token.mjs
+++ b/scripts/token.mjs
@@ -67,7 +67,7 @@ export default (Token) => class extends Token {
             || this.document.hasStatusEffect(CONFIG.specialStatusEffects.DEFEATED)
             || this.document.hasStatusEffect(CONFIG.specialStatusEffects.PETRIFIED)
             || this.document.hasStatusEffect(CONFIG.specialStatusEffects.SLEEPING)
-            || this.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS)) {
+            || (this.document.hasStatusEffect(CONFIG.specialStatusEffects.UNCONSCIOUS) && !game.settings.get("vision-5e", "unconsciousRetainsVision"))) {
             data.radius = 0;
             data.lightRadius = 0;
         } else {


### PR DESCRIPTION
Hi! I've just done this as a quick proof-of-concept for to resolve #80. Adds a new setting (I didn't bother with localizing, since you might not event want this) which just makes it so that unconscious tokens are still able to "see" if they would otherwise be able to. If you remove the change in `token.mjs` it'll still make the map invisible to the token, but keep modifying the `_canDetect` functions (though admittedly under normal circumstances it seems in V12 with 3.2 there's an outline of otherwise-would-be-visible tokens anyway - not sure whether it's a feature addition I missed but that would make this change irrelevant).

I've also got one ready to go on top of 1.14.3 if you wanted to release one last V11-compatible version with that as an added feature. No worries if not! Just thought it'd be a fun code exercise.